### PR TITLE
Warning cleanup and misc fixes  (3/3 mp15 patchset)

### DIFF
--- a/src/FMI_search.cpp
+++ b/src/FMI_search.cpp
@@ -64,7 +64,10 @@ FMI_search::FMI_search(char *ref_file_name)
     cp_occ = NULL;
 
     err_fread_noeof(&count[0], sizeof(int64_t), 5, cpstream);
-    cp_occ = (CP_OCC *)_mm_malloc(cp_occ_size * sizeof(CP_OCC), 64);
+    if ((cp_occ = (CP_OCC *)_mm_malloc(cp_occ_size * sizeof(CP_OCC), 64)) == NULL) {
+        fprintf(stderr, "ERROR! unable to allocated cp_occ memory\n");
+        exit(EXIT_FAILURE);
+    }
 
     err_fread_noeof(cp_occ, sizeof(CP_OCC), cp_occ_size, cpstream);
     int64_t ii = 0;

--- a/src/FMI_search.cpp
+++ b/src/FMI_search.cpp
@@ -29,6 +29,7 @@ Authors: Sanchit Misra <sanchit.misra@intel.com>; Vasimuddin Md <vasimuddin.md@i
 
 #include <stdio.h>
 #include "FMI_search.h"
+#include "utils.h"
 
 extern int myrank, num_ranks;
 
@@ -52,7 +53,7 @@ FMI_search::FMI_search(char *ref_file_name)
 		exit(EXIT_FAILURE);
     }
 
-    fread(&reference_seq_len, sizeof(int64_t), 1, cpstream);
+    err_fread_noeof(&reference_seq_len, sizeof(int64_t), 1, cpstream);
     assert(reference_seq_len > 0);
     assert(reference_seq_len <= (0xffffffffU * (int64_t)CP_BLOCK_SIZE));
 	if(myrank == 0)
@@ -62,10 +63,10 @@ FMI_search::FMI_search(char *ref_file_name)
     int64_t cp_occ_size = (reference_seq_len >> CP_SHIFT) + 1;
     cp_occ = NULL;
 
-    fread(&count[0], sizeof(int64_t), 5, cpstream);
+    err_fread_noeof(&count[0], sizeof(int64_t), 5, cpstream);
     cp_occ = (CP_OCC *)_mm_malloc(cp_occ_size * sizeof(CP_OCC), 64);
 
-    fread(cp_occ, sizeof(CP_OCC), cp_occ_size, cpstream);
+    err_fread_noeof(cp_occ, sizeof(CP_OCC), cp_occ_size, cpstream);
     int64_t ii = 0;
     for(ii = 0; ii < 5; ii++)// update read count structure
     {
@@ -73,8 +74,8 @@ FMI_search::FMI_search(char *ref_file_name)
     }
     sa_ms_byte = (int8_t *)_mm_malloc(reference_seq_len * sizeof(int8_t), 64);
     sa_ls_word = (uint32_t *)_mm_malloc(reference_seq_len * sizeof(uint32_t), 64);
-    fread(sa_ms_byte, sizeof(int8_t), reference_seq_len, cpstream);
-    fread(sa_ls_word, sizeof(uint32_t), reference_seq_len, cpstream);
+    err_fread_noeof(sa_ms_byte, sizeof(int8_t), reference_seq_len, cpstream);
+    err_fread_noeof(sa_ls_word, sizeof(uint32_t), reference_seq_len, cpstream);
     fclose(cpstream);
 
     sentinel_index = -1;

--- a/src/bandedSWA.cpp
+++ b/src/bandedSWA.cpp
@@ -584,8 +584,8 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
             {
 				{ // prefetch block
 					SeqPair spf = pairArray[i + j + PFD];
-					//_mm_prefetch((const char*) seqBufRef +  (int64_t)spf.id * MAX_SEQ_LEN_REF, 0);
-					//_mm_prefetch((const char*) seqBufRef +  (int64_t)spf.id * MAX_SEQ_LEN_REF + 64, 0);
+					//_mm_prefetch((const char*) seqBufRef +  (int64_t)spf.id * MAX_SEQ_LEN_REF, _MM_HINT_NTA);
+					//_mm_prefetch((const char*) seqBufRef +  (int64_t)spf.id * MAX_SEQ_LEN_REF + 64, _MM_HINT_NTA);
 				}
                 SeqPair sp = pairArray[i + j];
 				h0[j] = sp.h0;
@@ -629,8 +629,8 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
             {
 				{ // prefetch block
 					SeqPair spf = pairArray[i + j + PFD];
-					//_mm_prefetch((const char*) seqBufQer + (int64_t)spf.id * MAX_SEQ_LEN_QER, 0);
-					//_mm_prefetch((const char*) seqBufQer + (int64_t)spf.id * MAX_SEQ_LEN_QER + 64, 0);
+					//_mm_prefetch((const char*) seqBufQer + (int64_t)spf.id * MAX_SEQ_LEN_QER, _MM_HINT_NTA);
+					//_mm_prefetch((const char*) seqBufQer + (int64_t)spf.id * MAX_SEQ_LEN_QER + 64, _MM_HINT_NTA);
 				}
 				
                 SeqPair sp = pairArray[i + j];
@@ -1317,10 +1317,10 @@ void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
             {
 				{ // prefetch block
 					SeqPair spf = pairArray[i + j + PFD];
-					//_mm_prefetch((const char*) seqBufRef + (int64_t)spf.id * MAX_SEQ_LEN_REF, 0);
-					//_mm_prefetch((const char*) seqBufRef + (int64_t)spf.id * MAX_SEQ_LEN_REF + 64, 0);
-					_mm_prefetch((const char*) seqBufRef + (int64_t)spf.idr, 0);
-					_mm_prefetch((const char*) seqBufRef + (int64_t)spf.idr + 64, 0);
+					//_mm_prefetch((const char*) seqBufRef + (int64_t)spf.id * MAX_SEQ_LEN_REF, _MM_HINT_NTA);
+					//_mm_prefetch((const char*) seqBufRef + (int64_t)spf.id * MAX_SEQ_LEN_REF + 64, _MM_HINT_NTA);
+					_mm_prefetch((const char*) seqBufRef + (int64_t)spf.idr, _MM_HINT_NTA);
+					_mm_prefetch((const char*) seqBufRef + (int64_t)spf.idr + 64, _MM_HINT_NTA);
 				}
 
                 SeqPair sp = pairArray[i + j];
@@ -1361,10 +1361,10 @@ void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
             {
 				{ // prefetch block
 					SeqPair spf = pairArray[i + j + PFD];
-					//_mm_prefetch((const char*) seqBufQer + (int64_t)spf.id * MAX_SEQ_LEN_QER, 0);
-					//_mm_prefetch((const char*) seqBufQer + (int64_t)spf.id * MAX_SEQ_LEN_QER + 64, 0);
-					_mm_prefetch((const char*) seqBufQer + (int64_t)spf.idq, 0);
-					_mm_prefetch((const char*) seqBufQer + (int64_t)spf.idq + 64, 0);
+					//_mm_prefetch((const char*) seqBufQer + (int64_t)spf.id * MAX_SEQ_LEN_QER, _MM_HINT_NTA);
+					//_mm_prefetch((const char*) seqBufQer + (int64_t)spf.id * MAX_SEQ_LEN_QER + 64, _MM_HINT_NTA);
+					_mm_prefetch((const char*) seqBufQer + (int64_t)spf.idq, _MM_HINT_NTA);
+					_mm_prefetch((const char*) seqBufQer + (int64_t)spf.idq + 64, _MM_HINT_NTA);
 				}
 				
                 SeqPair sp = pairArray[i + j];
@@ -2214,10 +2214,10 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
             {
 				{ // prefetch block
 					SeqPair spf = pairArray[i + j + PFD8];
-					//_mm_prefetch((const char*) seqBufRef + (int64_t)spf.id * MAX_SEQ_LEN_REF, 0);
-					//_mm_prefetch((const char*) seqBufRef + (int64_t)spf.id * MAX_SEQ_LEN_REF + 64, 0);
-					_mm_prefetch((const char*) seqBufRef + (int64_t)spf.idr, 0);
-					_mm_prefetch((const char*) seqBufRef + (int64_t)spf.idr + 64, 0);
+					//_mm_prefetch((const char*) seqBufRef + (int64_t)spf.id * MAX_SEQ_LEN_REF, _MM_HINT_NTA);
+					//_mm_prefetch((const char*) seqBufRef + (int64_t)spf.id * MAX_SEQ_LEN_REF + 64, _MM_HINT_NTA);
+					_mm_prefetch((const char*) seqBufRef + (int64_t)spf.idr, _MM_HINT_NTA);
+					_mm_prefetch((const char*) seqBufRef + (int64_t)spf.idr + 64, _MM_HINT_NTA);
 				}
                 SeqPair sp = pairArray[i + j];
 				h0[j] = sp.h0;
@@ -2257,10 +2257,10 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
             {
 				{ // prefetch block
 					SeqPair spf = pairArray[i + j + PFD8];
-					//_mm_prefetch((const char*) seqBufQer + (int64_t)spf.id * MAX_SEQ_LEN_QER, 0);
-					//_mm_prefetch((const char*) seqBufQer + (int64_t)spf.id * MAX_SEQ_LEN_QER + 64, 0);
-					_mm_prefetch((const char*) seqBufQer + (int64_t)spf.idq, 0);
-					_mm_prefetch((const char*) seqBufQer + (int64_t)spf.idq + 64, 0);
+					//_mm_prefetch((const char*) seqBufQer + (int64_t)spf.id * MAX_SEQ_LEN_QER, _MM_HINT_NTA);
+					//_mm_prefetch((const char*) seqBufQer + (int64_t)spf.id * MAX_SEQ_LEN_QER + 64, _MM_HINT_NTA);
+					_mm_prefetch((const char*) seqBufQer + (int64_t)spf.idq, _MM_HINT_NTA);
+					_mm_prefetch((const char*) seqBufQer + (int64_t)spf.idq + 64, _MM_HINT_NTA);
 				}
 				
                 SeqPair sp = pairArray[i + j];
@@ -2931,10 +2931,10 @@ void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
             {
 				{ // prefetch block
 					SeqPair spf = pairArray[i + j + PFD16];
-					//_mm_prefetch((const char*) seqBufRef + (int64_t)spf.id * MAX_SEQ_LEN_REF, 0);
-					//_mm_prefetch((const char*) seqBufRef + (int64_t)spf.id * MAX_SEQ_LEN_REF + 64, 0);
-					_mm_prefetch((const char*) seqBufRef + (int64_t)spf.idr, 0);
-					_mm_prefetch((const char*) seqBufRef + (int64_t)spf.idr + 64, 0);					
+					//_mm_prefetch((const char*) seqBufRef + (int64_t)spf.id * MAX_SEQ_LEN_REF, _MM_HINT_NTA);
+					//_mm_prefetch((const char*) seqBufRef + (int64_t)spf.id * MAX_SEQ_LEN_REF + 64, _MM_HINT_NTA);
+					_mm_prefetch((const char*) seqBufRef + (int64_t)spf.idr, _MM_HINT_NTA);
+					_mm_prefetch((const char*) seqBufRef + (int64_t)spf.idr + 64, _MM_HINT_NTA);
 				}
                 SeqPair sp = pairArray[i + j];
 				h0[j] = sp.h0;
@@ -2975,10 +2975,10 @@ void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
             {
 				{ // prefetch block
 					SeqPair spf = pairArray[i + j + PFD16];
-					//_mm_prefetch((const char*) seqBufQer + (int64_t)spf.id * MAX_SEQ_LEN_QER, 0);
-					//_mm_prefetch((const char*) seqBufQer + (int64_t)spf.id * MAX_SEQ_LEN_QER + 64, 0);
-					_mm_prefetch((const char*) seqBufQer + (int64_t)spf.idq, 0);
-					_mm_prefetch((const char*) seqBufQer + (int64_t)spf.idq + 64, 0);					
+					//_mm_prefetch((const char*) seqBufQer + (int64_t)spf.id * MAX_SEQ_LEN_QER, _MM_HINT_NTA);
+					//_mm_prefetch((const char*) seqBufQer + (int64_t)spf.id * MAX_SEQ_LEN_QER + 64, _MM_HINT_NTA);
+					_mm_prefetch((const char*) seqBufQer + (int64_t)spf.idq, _MM_HINT_NTA);
+					_mm_prefetch((const char*) seqBufQer + (int64_t)spf.idq + 64, _MM_HINT_NTA);
 				}
 				
                 SeqPair sp = pairArray[i + j];
@@ -3752,8 +3752,8 @@ void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
             {
 				{ // prefetch block
 					SeqPair spf = pairArray[i + j + PFD];
-					_mm_prefetch((const char*) seqBufRef + (int64_t)spf.idr, 0);
-					_mm_prefetch((const char*) seqBufRef + (int64_t)spf.idr + 64, 0);
+					_mm_prefetch((const char*) seqBufRef + (int64_t)spf.idr, _MM_HINT_NTA);
+					_mm_prefetch((const char*) seqBufRef + (int64_t)spf.idr + 64, _MM_HINT_NTA);
 				}
                 SeqPair sp = pairArray[i + j];
 				h0[j] = sp.h0;
@@ -3794,10 +3794,10 @@ void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
             {
 				{ // prefetch block
 					SeqPair spf = pairArray[i + j + PFD];
-					//_mm_prefetch((const char*) seqBuf + (2 * (int64_t)spf.id + 1) * MAX_SEQ_LEN, 0);
-					//_mm_prefetch((const char*) seqBuf + (2 * (int64_t)spf.id + 1) * MAX_SEQ_LEN + 64, 0);
-					_mm_prefetch((const char*) seqBufQer + (int64_t)spf.idq, 0);
-					_mm_prefetch((const char*) seqBufQer + (int64_t)spf.idq + 64, 0);
+					//_mm_prefetch((const char*) seqBuf + (2 * (int64_t)spf.id + 1) * MAX_SEQ_LEN, _MM_HINT_NTA);
+					//_mm_prefetch((const char*) seqBuf + (2 * (int64_t)spf.id + 1) * MAX_SEQ_LEN + 64, _MM_HINT_NTA);
+					_mm_prefetch((const char*) seqBufQer + (int64_t)spf.idq, _MM_HINT_NTA);
+					_mm_prefetch((const char*) seqBufQer + (int64_t)spf.idq + 64, _MM_HINT_NTA);
 				}
 				
                 SeqPair sp = pairArray[i + j];
@@ -4553,8 +4553,8 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
             {
 				{ // prefetch block
 					SeqPair spf = pairArray[i + j + PFD];
-					// _mm_prefetch((const char*) seqBuf + 2 * (int64_t)spf.id * MAX_SEQ_LEN, 0);
-					// _mm_prefetch((const char*) seqBuf + 2 * (int64_t)spf.id * MAX_SEQ_LEN + 64, 0);
+					// _mm_prefetch((const char*) seqBuf + 2 * (int64_t)spf.id * MAX_SEQ_LEN, _MM_HINT_NTA);
+					// _mm_prefetch((const char*) seqBuf + 2 * (int64_t)spf.id * MAX_SEQ_LEN + 64, _MM_HINT_NTA);
 				}
                 SeqPair sp = pairArray[i + j];
 				h0[j] = sp.h0;
@@ -4595,8 +4595,8 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
             {
 				{ // prefetch block
 					SeqPair spf = pairArray[i + j + PFD];
-					//_mm_prefetch((const char*) seqBuf + (2 * (int64_t)spf.id + 1) * MAX_SEQ_LEN, 0);
-					//_mm_prefetch((const char*) seqBuf + (2 * (int64_t)spf.id + 1) * MAX_SEQ_LEN + 64, 0);
+					//_mm_prefetch((const char*) seqBuf + (2 * (int64_t)spf.id + 1) * MAX_SEQ_LEN, _MM_HINT_NTA);
+					//_mm_prefetch((const char*) seqBuf + (2 * (int64_t)spf.id + 1) * MAX_SEQ_LEN + 64, _MM_HINT_NTA);
 				}
 				
                 SeqPair sp = pairArray[i + j];

--- a/src/bntseq.cpp
+++ b/src/bntseq.cpp
@@ -303,6 +303,7 @@ int64_t bns_fasta2bntseq(gzFile fp_fa, const char *prefix, int for_only)
 	bns->anns = (bntann1_t*)calloc(m_seqs, sizeof(bntann1_t));
 	bns->ambs = (bntamb1_t*)calloc(m_holes, sizeof(bntamb1_t));
 	pac = (uint8_t*) calloc(m_pac/4, 1);
+	if (pac == NULL) { perror("Allocation of pac failed"); exit(EXIT_FAILURE); }
 	q = bns->ambs;
 	assert(strlen(prefix) + 4 < 1024);
 	strcpy(name, prefix); strcat(name, ".pac");
@@ -312,6 +313,7 @@ int64_t bns_fasta2bntseq(gzFile fp_fa, const char *prefix, int for_only)
 	if (!for_only) { // add the reverse complemented sequence
 		m_pac = (bns->l_pac * 2 + 3) / 4 * 4;
 		pac = (uint8_t*) realloc(pac, m_pac/4);
+		if (pac == NULL) { perror("Reallocation of pac failed"); exit(EXIT_FAILURE); }
 		memset(pac + (bns->l_pac+3)/4, 0, (m_pac - (bns->l_pac+3)/4*4) / 4);
 		for (l = bns->l_pac - 1; l >= 0; --l, ++bns->l_pac)
 			_set_pac(pac, bns->l_pac, 3-_get_pac(pac, l));

--- a/src/bntseq.cpp
+++ b/src/bntseq.cpp
@@ -102,7 +102,7 @@ void bns_dump(const bntseq_t *bns, const char *prefix)
 
 bntseq_t *bns_restore_core(const char *ann_filename, const char* amb_filename, const char* pac_filename)
 {
-	char str[8192];
+	char str[8193];
 	FILE *fp;
 	const char *fname;
 	bntseq_t *bns;

--- a/src/bwa.cpp
+++ b/src/bwa.cpp
@@ -120,15 +120,15 @@ bseq1_t *bseq_read(int64_t chunk_size, int *n_, void *ks1_, void *ks2_,
 #else
 			//kstring_t kstr;
 			//printf("%d\n", ks_getuntil2(kst, KS_SEP_LINE, &kstr, 0, 0));
-			fgets((char*) buf, len, fpp);
+			err_fgets((char*) buf, len, fpp);
 			size2 += strlen((char*) buf);
 			// printf("First line: %d, %s\n", strlen(buf), buf);
-			fgets((char*) buf, len, fpp);
+			err_fgets((char*) buf, len, fpp);
 			size2 += strlen((char*) buf);
 			if (seqs[n].qual != NULL) {
-				fgets((char*) buf, len, fpp);
+				err_fgets((char*) buf, len, fpp);
 				size2 += strlen((char*) buf);
-				fgets((char*) buf, len, fpp);
+				err_fgets((char*) buf, len, fpp);
 				size2 += strlen((char*) buf);
 			}
 #endif

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -2014,7 +2014,7 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
 		mem_alnreg_v *av = &av_v[l];  // alignment
 		mem_chain_t *c;
 
-		_mm_prefetch((const char*) query, 0);
+		_mm_prefetch((const char*) query, _MM_HINT_NTA);
 		
 		// aln mem allocation
 		av->m = 0;
@@ -2032,8 +2032,8 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
 			int64_t tmp = 0;
 			if (c->n == 0) continue;
 			
-			_mm_prefetch((const char*) (srtg + spos + 64), 0);
-			_mm_prefetch((const char*) (lim_g), 0);
+			_mm_prefetch((const char*) (srtg + spos + 64), _MM_HINT_NTA);
+			_mm_prefetch((const char*) (lim_g), _MM_HINT_NTA);
 			
 			// get the max possible span
 			rmax[0] = l_pac<<1; rmax[1] = 0;
@@ -2070,8 +2070,8 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
 				assert(c->rid == rid);
 			}
 
-			_mm_prefetch((const char*) rseq, 0);
-			// _mm_prefetch((const char*) rseq + 64, 0);
+			_mm_prefetch((const char*) rseq, _MM_HINT_NTA);
+			// _mm_prefetch((const char*) rseq + 64, _MM_HINT_NTA);
 			
 			// assert(c->n < MAX_SEEDS_PER_READ);  // temp
 			if (c->n > srt_size) {

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -85,11 +85,12 @@ static inline int cal_max_gap(const mem_opt_t *opt, int qlen)
 static smem_aux_t *smem_aux_init()
 {
 	smem_aux_t *a;
-	a = (smem_aux_t *) calloc(BATCH_SIZE, sizeof(smem_aux_t));
+	if ((a = (smem_aux_t *) calloc(BATCH_SIZE, sizeof(smem_aux_t))) == NULL) { fprintf(stderr, "ERROR: out of memory %s\n", __func__); exit(1); }
 	for (int i=0; i<BATCH_SIZE; i++)
 	{
 		a[i].tmpv[0] = (bwtintv_v *) calloc(1, sizeof(bwtintv_v));
 		a[i].tmpv[1] = (bwtintv_v *) calloc(1, sizeof(bwtintv_v));
+		if (!a[i].tmpv[0] || !a[i].tmpv[1]) { fprintf(stderr, "ERROR: out of memory %s\n", __func__); exit(1); }
 	}
 	return a;
 }
@@ -111,7 +112,7 @@ static void smem_aux_destroy(smem_aux_t *a)
 mem_opt_t *mem_opt_init()
 {
 	mem_opt_t *o;
-	o = (mem_opt_t *) calloc(1, sizeof(mem_opt_t));
+	if ((o = (mem_opt_t *) calloc(1, sizeof(mem_opt_t))) == NULL)  { fprintf(stderr, "ERROR: out of memory\n"); exit(1); }
 	o->flag = 0;
 	o->a = 1; o->b = 4;
 	o->o_del = o->o_ins = 6;
@@ -391,13 +392,13 @@ static int test_and_merge(const mem_opt_t *opt, int64_t l_pac, mem_chain_t *c,
 			int pm = c->m;			
 			c->m <<= 1;
 			if (pm == SEEDS_PER_CHAIN) {  // re-new memory
-				auxSeedBuf = (mem_seed_t *) calloc(c->m, sizeof(mem_seed_t));
+				if ((auxSeedBuf = (mem_seed_t *) calloc(c->m, sizeof(mem_seed_t))) == NULL) { fprintf(stderr, "ERROR: out of memory auxSeedBuf\n"); exit(1); }
 				memcpy((char*) (auxSeedBuf), c->seeds, c->n * sizeof(mem_seed_t));
 				c->seeds = auxSeedBuf;
 				tprof[PE13][tid]++;
 			} else {  // new memory
 				// fprintf(stderr, "[%0.4d] re-allocing old seed, m: %d\n", tid, c->m);
-				auxSeedBuf = (mem_seed_t *) realloc(c->seeds, c->m * sizeof(mem_seed_t));
+				if ((auxSeedBuf = (mem_seed_t *) realloc(c->seeds, c->m * sizeof(mem_seed_t))) == NULL) { fprintf(stderr, "ERROR: out of memory auxSeedBuf\n"); exit(1); }
 				c->seeds = auxSeedBuf;
 			}
             memset((char*) (c->seeds + c->n), 0, (c->m - c->n) * sizeof(mem_seed_t));			

--- a/src/bwtbuild.cpp
+++ b/src/bwtbuild.cpp
@@ -38,6 +38,7 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 #include <ctime>
 #include<fstream>
 #include <emmintrin.h>
+#include <inttypes.h>
 
 #include "sais.h"
 
@@ -688,7 +689,7 @@ int build_index(const char *prefix) {
 
 int build_index(const char *prefix) {
 
-    int64_t startTick;
+    uint64_t startTick;
     startTick = __rdtsc();
     cur_alloc = 0;
 
@@ -706,7 +707,7 @@ int build_index(const char *prefix) {
     sprintf(binary_ref_name, "%s.0123", prefix);
     std::fstream binary_ref_stream (binary_ref_name, std::ios::out | std::ios::binary);
     binary_ref_stream.seekg(0);
-    fprintf(stderr, "init ticks = %ld\n", __rdtsc() - startTick);
+    fprintf(stderr, "init ticks = %" PRIu64 "\n", __rdtsc() - startTick);
     startTick = __rdtsc();
     int64_t i, count[16];
 	memset(count, 0, sizeof(int64_t) * 16);
@@ -738,7 +739,7 @@ int build_index(const char *prefix) {
     count[0]=0;
     fprintf(stderr, "ref seq len = %ld\n", pac_len);
     binary_ref_stream.write(binary_ref_seq, pac_len * sizeof(char));
-    fprintf(stderr, "binary seq ticks = %ld\n", __rdtsc() - startTick);
+    fprintf(stderr, "binary seq ticks = %" PRIu64 "\n", __rdtsc() - startTick);
     startTick = __rdtsc();
 
     size = (pac_len + 2) * sizeof(int64_t);
@@ -748,7 +749,7 @@ int build_index(const char *prefix) {
     startTick = __rdtsc();
 	status = saisxx(reference_seq.c_str(), suffix_array + 1, pac_len);
 	suffix_array[0] = pac_len;
-    fprintf(stderr, "build index ticks = %ld\n", __rdtsc() - startTick);
+    fprintf(stderr, "build index ticks = %" PRIu64 "\n", __rdtsc() - startTick);
     startTick = __rdtsc();
 
     build_fm_index_avx(prefix, binary_ref_seq, pac_len, suffix_array, count);

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -56,49 +56,49 @@ int64_t nreads, memSize;
 // ---------------
 void __cpuid(unsigned int i, unsigned int cpuid[4]) {
 #ifdef _WIN32
-  __cpuid((int *) cpuid, (int)i);
+	__cpuid((int *) cpuid, (int)i);
 
 #else
-  asm volatile
-    ("cpuid" : "=a" (cpuid[0]), "=b" (cpuid[1]), "=c" (cpuid[2]), "=d" (cpuid[3])
-     : "0" (i), "2" (0));
+	asm volatile
+		("cpuid" : "=a" (cpuid[0]), "=b" (cpuid[1]), "=c" (cpuid[2]), "=d" (cpuid[3])
+			: "0" (i), "2" (0));
 #endif
 }
 
 
 int HTStatus()
 {
-  unsigned int cpuid[4];
-  char platform_vendor[12];
-  __cpuid(0, cpuid);
-  ((unsigned int *)platform_vendor)[0] = cpuid[1]; // B
-  ((unsigned int *)platform_vendor)[1] = cpuid[3]; // D
-  ((unsigned int *)platform_vendor)[2] = cpuid[2]; // C
-  std::string platform = std::string(platform_vendor, 12);
+	unsigned int cpuid[4];
+	char platform_vendor[12];
+	__cpuid(0, cpuid);
+	((unsigned int *)platform_vendor)[0] = cpuid[1]; // B
+	((unsigned int *)platform_vendor)[1] = cpuid[3]; // D
+	((unsigned int *)platform_vendor)[2] = cpuid[2]; // C
+	std::string platform = std::string(platform_vendor, 12);
 
-  __cpuid(1, cpuid);
-  unsigned int platform_features = cpuid[3]; //D
+	__cpuid(1, cpuid);
+	unsigned int platform_features = cpuid[3]; //D
 
-  // __cpuid(1, cpuid);
-  unsigned int num_logical_cpus = (cpuid[1] >> 16) & 0xFF; // B[23:16]
-  // fprintf(stderr, "#logical cpus: ", num_logical_cpus);
-  
-  unsigned int num_cores = -1;
-  if (platform == "GenuineIntel") {
-	  __cpuid(4, cpuid);
-	  num_cores = ((cpuid[0] >> 26) & 0x3f) + 1; //A[31:26] + 1
-	  fprintf(stderr, "Platform vendor: Intel.\n");
-  } else  {
-	  fprintf(stderr, "Platform vendor unknown.\n");
-  }
+	// __cpuid(1, cpuid);
+	unsigned int num_logical_cpus = (cpuid[1] >> 16) & 0xFF; // B[23:16]
+	// fprintf(stderr, "#logical cpus: ", num_logical_cpus);
 
-  // fprintf(stderr, "#physical cpus: ", num_cores);
+	unsigned int num_cores = -1;
+	if (platform == "GenuineIntel") {
+		__cpuid(4, cpuid);
+		num_cores = ((cpuid[0] >> 26) & 0x3f) + 1; //A[31:26] + 1
+		fprintf(stderr, "Platform vendor: Intel.\n");
+	} else  {
+		fprintf(stderr, "Platform vendor unknown.\n");
+	}
 
-  int ht = platform_features & (1 << 28) && num_cores < num_logical_cpus;
-  if (ht)
-	  fprintf(stderr, "CPUs support hyperThreading !!\n");
+	// fprintf(stderr, "#physical cpus: ", num_cores);
 
-  return ht;
+	int ht = platform_features & (1 << 28) && num_cores < num_logical_cpus;
+	if (ht)
+		fprintf(stderr, "CPUs support hyperThreading !!\n");
+
+	return ht;
 }
 
 //---------------
@@ -358,7 +358,7 @@ ktp_data_t *kt_pipeline(void *shared, int step, void *data, mem_opt_t *opt, work
 				fputs(ret->seqs[i].sam, aux->fp);
 			}
 			free(ret->seqs[i].name); free(ret->seqs[i].comment);
-		    free(ret->seqs[i].seq); free(ret->seqs[i].qual);
+			free(ret->seqs[i].seq); free(ret->seqs[i].qual);
 			free(ret->seqs[i].sam);
 		}
 		free(ret->seqs);
@@ -561,7 +561,7 @@ static int process(void *shared, gzFile gfp, gzFile gfp2, int pipe_threads)
 	/* Dealloc memory allcoated in the header section */	
 	free(w.chain_ar);
 	free(w.regs);
-    free(w.seedBuf);
+	free(w.seedBuf);
 
 	_mm_free(w.mmc.seqBufLeftRef);
 	_mm_free(w.mmc.seqBufRightRef);
@@ -771,12 +771,12 @@ int main_mem(int argc, char *argv[])
 		}
 		else if (c == 'R')
 		{
-		if ((rg_line = bwa_set_rg(optarg)) == 0) {
-			free(opt);
-			if (is_o)
-				fclose(aux.fp);
+			if ((rg_line = bwa_set_rg(optarg)) == 0) {
+				free(opt);
+				if (is_o)
+					fclose(aux.fp);
 				return 1;
-            }
+			}
 		}
 		else if (c == 'H')
 		{
@@ -881,7 +881,7 @@ int main_mem(int argc, char *argv[])
 			if (is_o)
 				fclose(aux.fp);
 			return 1;
-        }
+		}
 	} else update_a(opt, &opt0);
 	
 	/* Matrix for SWA */
@@ -900,8 +900,8 @@ int main_mem(int argc, char *argv[])
 		tim = __rdtsc();
 		fprintf(stderr, "Reading reference genome..\n");
 		
-        char binary_seq_file[200];
-        sprintf(binary_seq_file, "%s.0123", argv[optind]);
+		char binary_seq_file[200];
+		sprintf(binary_seq_file, "%s.0123", argv[optind]);
 		
 		fprintf(stderr, "Binary seq file = %s\n", binary_seq_file);
 		FILE *fr = fopen(binary_seq_file, "r");

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -106,24 +106,24 @@ int64_t get_limit_fsize(FILE *fpp, int64_t nread_lim,
 						char buf[], char buf1[]) {
 	
 	int64_t val = 0, len = 10000;
-	fseek(fpp, 0, SEEK_END);
-	val = ftell(fpp);
+	err_fseek(fpp, 0, SEEK_END);
+	val = err_ftell(fpp);
 	if (nread_lim >= val)
 		return val;
 
-	fseek(fpp, nread_lim, SEEK_SET);
+	err_fseek(fpp, nread_lim, SEEK_SET);
 	int64_t position = nread_lim;
 	while(true) {
 		if (fgets((char*) buf, len, fpp) != NULL) {
 			if (buf[0] == '@') {
 				int64_t pos = ftell(fpp);
-				fgets((char*) buf1, len, fpp);
-				fgets((char*) buf1, len, fpp);
+				err_fgets((char*) buf1, len, fpp);
+				err_fgets((char*) buf1, len, fpp);
 				if (buf1[0] == '+')
 					break;
-				fseek(fpp, pos, SEEK_SET);
+				err_fseek(fpp, pos, SEEK_SET);
 			}
-			position = ftell(fpp);
+			position = err_ftell(fpp);
 		}
 		else break;
 	}
@@ -918,7 +918,7 @@ int main_mem(int argc, char *argv[])
 		rewind(fr);
 
 		/* Reading ref. sequence */
-		fread(ref_string, 1, rlen, fr);
+		err_fread_noeof(ref_string, 1, rlen, fr);
 
 		uint64_t timer  = __rdtsc();
 		tprof[REF_IO][0] += timer - tim;

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -421,8 +421,8 @@ static int process(void *shared, gzFile gfp, gzFile gfp2, int pipe_threads)
 	mem_opt_t	*opt			  = aux->opt;
 
 	nthreads = opt->n_threads; // global variable for profiling!
-	int  deno = 1;
 #if NUMA_ENABLED
+	int  deno = 1;
 	int tc = numa_num_task_cpus();
 	int tn = numa_num_task_nodes();
 	int tcc = numa_num_configured_cpus();

--- a/src/kswv.cpp
+++ b/src/kswv.cpp
@@ -28,6 +28,7 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 *****************************************************************************************/
 
 // #include <immintrin.h>
+#include <stddef.h>
 #include <string.h>
 #include <unistd.h>
 #include "kswv.h"
@@ -430,7 +431,8 @@ int kswv::kswv512_u8(uint8_t seq1SoA[],
 {
 	
 	int m_b, n_b;
-	uint8_t minsc[SIMD_WIDTH8] = {0}, endsc[SIMD_WIDTH8] = {0};
+	uint8_t minsc[SIMD_WIDTH8] alignas(64) = {0};
+	uint8_t endsc[SIMD_WIDTH8] alignas(64) = {0};
 	uint64_t *b;
 
 	__m512i zero512 = _mm512_setzero_si512();

--- a/src/kswv.cpp
+++ b/src/kswv.cpp
@@ -2260,11 +2260,11 @@ int kswv::kswv512_16_exp(int16_t seq1SoA[],
 	int16_t	*F		= F16 + tid * SIMD_WIDTH16 * MAX_SEQ_LEN_QER_SAM;
 	int16_t	*rowMax	= rowMax16 + tid * SIMD_WIDTH16 * MAX_SEQ_LEN_REF_SAM;
 	
-	_mm_prefetch((const char*) (F + SIMD_WIDTH16), 0);
-	_mm_prefetch((const char*) seq2SoA, 0);
-	_mm_prefetch((const char*) seq1SoA, 0);
-	_mm_prefetch((const char*) (H1 + SIMD_WIDTH16), 0);
-	_mm_prefetch((const char*) (F + SIMD_WIDTH16), 0);
+	_mm_prefetch((const char*) (F + SIMD_WIDTH16), _MM_HINT_NTA);
+	_mm_prefetch((const char*) seq2SoA, _MM_HINT_NTA);
+	_mm_prefetch((const char*) seq1SoA, _MM_HINT_NTA);
+	_mm_prefetch((const char*) (H1 + SIMD_WIDTH16), _MM_HINT_NTA);
+	_mm_prefetch((const char*) (F + SIMD_WIDTH16), _MM_HINT_NTA);
 
 	for (int i=ncol; i >= 0; i--) {
 		_mm512_store_si512((__m512*) (H0 + i * SIMD_WIDTH16), zero512);
@@ -2533,11 +2533,11 @@ void kswv::kswv512_16(int16_t seq1SoA[],
 
 	int16_t	*rowMax	= rowMax16 + tid * SIMD_WIDTH16 * MAX_SEQ_LEN_REF_SAM;
 	
-	_mm_prefetch((const char*) (F + SIMD_WIDTH16), 0);
-	_mm_prefetch((const char*) seq2SoA, 0);
-	_mm_prefetch((const char*) seq1SoA, 0);
-	_mm_prefetch((const char*) (H1 + SIMD_WIDTH16), 0);
-	_mm_prefetch((const char*) (F + SIMD_WIDTH16), 0);
+	_mm_prefetch((const char*) (F + SIMD_WIDTH16), _MM_HINT_NTA);
+	_mm_prefetch((const char*) seq2SoA, _MM_HINT_NTA);
+	_mm_prefetch((const char*) seq1SoA, _MM_HINT_NTA);
+	_mm_prefetch((const char*) (H1 + SIMD_WIDTH16), _MM_HINT_NTA);
+	_mm_prefetch((const char*) (F + SIMD_WIDTH16), _MM_HINT_NTA);
 
 	for (int i=ncol; i >= 0; i--) {
 		_mm512_store_si512((__m512*) (H0 + i * SIMD_WIDTH16), zero512);

--- a/src/runsimd.cpp
+++ b/src/runsimd.cpp
@@ -113,7 +113,7 @@ static int exe_path(const char *exe, int max, char buf[], int *base_st)
 		struct stat st;
 		env = getenv("PATH");
 		env_len = strlen(env);
-		tmp = (char*)malloc(env_len + len + 2);
+		if ((tmp = (char*)malloc(env_len + len + 2)) == NULL) { fprintf( stderr, "ERROR: out of memory %s", __func__); }
 		for (p = q = env;; ++p) {
 			if (*p == ':' || *p == 0) {
 				strncpy(tmp, q, p - q);
@@ -158,7 +158,10 @@ int main(int argc, char *argv[])
 	}
 	//printf("%s\n", buf);
 	buf_len = strlen(buf);
-	prefix = (char*)malloc(buf_len + (strlen(argv0) - base_st) + 20);
+	if ((prefix = (char*)malloc(buf_len + (strlen(argv0) - base_st) + 20)) == NULL) {
+		fprintf(stderr, "ERROR: out of memory.\n");
+		return 1;
+        }
 	strcpy(prefix, buf);
 	strcpy(prefix + buf_len, &argv0[base_st]);
 	prefix_len = strlen(prefix);

--- a/src/runsimd.cpp
+++ b/src/runsimd.cpp
@@ -109,7 +109,7 @@ static int exe_path(const char *exe, int max, char buf[], int *base_st)
 		buf[abs_len + last_slash + 2] = 0;
 	} else {
 		char *env, *p, *q, *tmp;
-		int env_len, found = 0, ret;
+		int env_len, found = 0;
 		struct stat st;
 		env = getenv("PATH");
 		env_len = strlen(env);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -208,6 +208,17 @@ int err_fputc(int c, FILE *stream)
 	return ret;
 }
 
+char* err_fgets(char *str, int size, FILE *stream)
+{
+	char* ret = fgets(str, size, stream );
+	if (ret == NULL)
+	{
+		_err_fatal_simple("fgets", strerror(errno));
+	}
+
+	return ret;
+}
+
 int err_fputs(const char *s, FILE *stream)
 {
 	int ret = fputs(s, stream);

--- a/src/utils.h
+++ b/src/utils.h
@@ -84,7 +84,7 @@ extern "C" {
 	FILE *err_xopen_core(const char *func, const char *fn, const char *mode);
 	FILE *err_xreopen_core(const char *func, const char *fn, const char *mode, FILE *fp);
 	gzFile err_xzopen_core(const char *func, const char *fn, const char *mode);
-    size_t err_fwrite(const void *ptr, size_t size, size_t nmemb, FILE *stream);
+	size_t err_fwrite(const void *ptr, size_t size, size_t nmemb, FILE *stream);
 	size_t err_fread_noeof(void *ptr, size_t size, size_t nmemb, FILE *stream);
 
 	int err_gzread(gzFile file, void *ptr, unsigned int len);

--- a/src/utils.h
+++ b/src/utils.h
@@ -97,6 +97,7 @@ extern "C" {
         ATTRIBUTE((format(printf, 1, 2)));
 	int err_fputc(int c, FILE *stream);
 #define err_putchar(C) err_fputc((C), stdout)
+	char* err_fgets(char *str, int size, FILE *stream);
 	int err_fputs(const char *s, FILE *stream);
 	int err_puts(const char *s);
 	int err_fflush(FILE *stream);


### PR DESCRIPTION
Built on top of #40, #42 this series of patches does the following:
- Fixes a few printf format specifiers
- Changes 0 in _mmhint to _MM_HINT_NTA so that compiler doesn't complain about int being passed to enum and the code is more readable.
- Fixes a few whitespace inconsistencies in fastmap.cpp some of which were deceptive depending on how many spaces your editor is set to give for tabs.