### PR TITLE
Fix object link order in GCC invocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ multi:
 	$(CXX) -Wall -O3 src/runsimd.cpp -o bwa-mem2
 
 $(EXE):$(BWA_LIB) src/main.o
-	$(CXX) $(CXXFLAGS) $(BWA_LIB) src/main.o -o $@ $(LIBS)
+	$(CXX) $(CXXFLAGS) src/main.o $(BWA_LIB) $(LIBS) -o $@
 
 $(BWA_LIB):$(OBJS)
 	ar rcs $(BWA_LIB) $(OBJS)


### PR DESCRIPTION
Before this change, `make multi` on Ubuntu 18.04 resulted in multiple undefined reference errors due both to linked third-party libraries as well as symbols from `libbwa.a` not being found. This change fixes that.