### PR TITLE
Use all optimization flags for AVX/SSE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,18 +46,18 @@ ifneq ($(portable),)
 endif
 
 ifeq ($(arch),sse)
-		ARCH_FLAGS=-msse4.1
+		ARCH_FLAGS=-msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2
 else ifeq ($(arch),avx2)
 	ifeq ($(CXX), icpc)
 		ARCH_FLAGS=-xCORE-AVX2
 	else	
-		ARCH_FLAGS=-mavx2
+		ARCH_FLAGS=-mavx -mavx2
 	endif
 else ifeq ($(arch),avx512)
 	ifeq ($(CXX), icpc)
 		ARCH_FLAGS=-xCORE-AVX512
 	else	
-		ARCH_FLAGS=-mavx512bw
+		ARCH_FLAGS=-mavx -mavx2 -mavx512bw
 	endif
 else ifeq ($(arch),native)
 	ARCH_FLAGS=-march=native


### PR DESCRIPTION
Please note: AVX and SSE flags in GCC do not inherit all previous version's flags.

Therefore, to include all SSE flags (for example) up to version 4.1 you need to specify:
```
-msse -msse2 -msse3 -msse4 -msse4.1
```
Please test this patch for speedups with `arch=sse` or `arch=avx2` or `arch=avx512` as when I tested the compilation, I got different sized binaries (but have not tested the run time for improvements).
