### PR TITLE
Optimization flags for SSE for 8% speedup when compiled with GCC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ ifeq ($(CXX), icpc)
 else ifeq ($(CXX), g++)
 	CC=gcc
 endif		
-ARCH_FLAGS=	-msse4.1
+ARCH_FLAGS=	-msse -msse2 -msse3 -mssse3 -msse4.1
 MEM_FLAGS=	-DSAIS=1
 CPPFLAGS+=	-DENABLE_PREFETCH -DV17=1 $(MEM_FLAGS) 
 INCLUDES=   -Isrc -Iext/safestringlib/include
@@ -52,9 +52,9 @@ BWA_LIB=    libbwa.a
 SAFE_STR_LIB=    ext/safestringlib/libsafestring.a
 
 ifeq ($(arch),sse41)
-	ARCH_FLAGS=-msse4.1
+	ARCH_FLAGS=-msse -msse2 -msse3 -mssse3 -msse4.1
 else ifeq ($(arch),sse42)
-	ARCH_FLAGS=-msse4.2
+	ARCH_FLAGS=-msse -msse2 -msse3 -mssse3 -msse4.1 -msse4.2
 else ifeq ($(arch),avx)
 	ifeq ($(CXX), icpc)
 		ARCH_FLAGS=-mavx ##-xAVX


### PR DESCRIPTION
@lh3 Sorry for previous pull request that had no evidence, so I ran this commit vs master on a human exome and got 8% speedup using `arch=sse`: 

TESTED on GCC 4.8.5 with 4GBx2 (R1+R2) human exome data:

Master:
```
$ make clean && make arch=sse
...
$ time bwa-mem2.gcc485.sse.master mem -t8 -k19 Homo_sapiens_assembly38.fasta sample_R1.fastq.gz sample_R2.fastq.gz -o master_sse.sam
real    37m32.307s
user    294m9.328s
sys 3m17.051s
```

This commit:
```
$ make clean && make arch=sse
...
$ time bwa-mem2.gcc485.sse.allflags mem -t8 -k19 Homo_sapiens_assembly38.fasta sample_R1.fastq.gz sample_R2.fastq.gz -o allflags_sse.sam
real    34m29.321s
user    267m27.421s
sys 3m6.138s
```

Output file size:
43557430191 master_sse.sam
43557430191 allflags_sse.sam
(Identical except headers)

Results in 8% speedup.