### PR TITLE
IO checks (1/3 mp15 patchset)

### DIFF
--- a/src/FMI_search.cpp
+++ b/src/FMI_search.cpp
@@ -29,6 +29,7 @@ Authors: Sanchit Misra <sanchit.misra@intel.com>; Vasimuddin Md <vasimuddin.md@i
 
 #include <stdio.h>
 #include "FMI_search.h"
+#include "utils.h"
 
 extern int myrank, num_ranks;
 
@@ -52,7 +53,7 @@ FMI_search::FMI_search(char *ref_file_name)
 		exit(EXIT_FAILURE);
     }
 
-    fread(&reference_seq_len, sizeof(int64_t), 1, cpstream);
+    err_fread_noeof(&reference_seq_len, sizeof(int64_t), 1, cpstream);
     assert(reference_seq_len > 0);
     assert(reference_seq_len <= (0xffffffffU * (int64_t)CP_BLOCK_SIZE));
 	if(myrank == 0)
@@ -62,10 +63,10 @@ FMI_search::FMI_search(char *ref_file_name)
     int64_t cp_occ_size = (reference_seq_len >> CP_SHIFT) + 1;
     cp_occ = NULL;
 
-    fread(&count[0], sizeof(int64_t), 5, cpstream);
+    err_fread_noeof(&count[0], sizeof(int64_t), 5, cpstream);
     cp_occ = (CP_OCC *)_mm_malloc(cp_occ_size * sizeof(CP_OCC), 64);
 
-    fread(cp_occ, sizeof(CP_OCC), cp_occ_size, cpstream);
+    err_fread_noeof(cp_occ, sizeof(CP_OCC), cp_occ_size, cpstream);
     int64_t ii = 0;
     for(ii = 0; ii < 5; ii++)// update read count structure
     {
@@ -73,8 +74,8 @@ FMI_search::FMI_search(char *ref_file_name)
     }
     sa_ms_byte = (int8_t *)_mm_malloc(reference_seq_len * sizeof(int8_t), 64);
     sa_ls_word = (uint32_t *)_mm_malloc(reference_seq_len * sizeof(uint32_t), 64);
-    fread(sa_ms_byte, sizeof(int8_t), reference_seq_len, cpstream);
-    fread(sa_ls_word, sizeof(uint32_t), reference_seq_len, cpstream);
+    err_fread_noeof(sa_ms_byte, sizeof(int8_t), reference_seq_len, cpstream);
+    err_fread_noeof(sa_ls_word, sizeof(uint32_t), reference_seq_len, cpstream);
     fclose(cpstream);
 
     sentinel_index = -1;

--- a/src/bwa.cpp
+++ b/src/bwa.cpp
@@ -120,15 +120,15 @@ bseq1_t *bseq_read(int64_t chunk_size, int *n_, void *ks1_, void *ks2_,
 #else
 			//kstring_t kstr;
 			//printf("%d\n", ks_getuntil2(kst, KS_SEP_LINE, &kstr, 0, 0));
-			fgets((char*) buf, len, fpp);
+			err_fgets((char*) buf, len, fpp);
 			size2 += strlen((char*) buf);
 			// printf("First line: %d, %s\n", strlen(buf), buf);
-			fgets((char*) buf, len, fpp);
+			err_fgets((char*) buf, len, fpp);
 			size2 += strlen((char*) buf);
 			if (seqs[n].qual != NULL) {
-				fgets((char*) buf, len, fpp);
+				err_fgets((char*) buf, len, fpp);
 				size2 += strlen((char*) buf);
-				fgets((char*) buf, len, fpp);
+				err_fgets((char*) buf, len, fpp);
 				size2 += strlen((char*) buf);
 			}
 #endif

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -106,24 +106,24 @@ int64_t get_limit_fsize(FILE *fpp, int64_t nread_lim,
 						char buf[], char buf1[]) {
 	
 	int64_t val = 0, len = 10000;
-	fseek(fpp, 0, SEEK_END);
-	val = ftell(fpp);
+	err_fseek(fpp, 0, SEEK_END);
+	val = err_ftell(fpp);
 	if (nread_lim >= val)
 		return val;
 
-	fseek(fpp, nread_lim, SEEK_SET);
+	err_fseek(fpp, nread_lim, SEEK_SET);
 	int64_t position = nread_lim;
 	while(true) {
 		if (fgets((char*) buf, len, fpp) != NULL) {
 			if (buf[0] == '@') {
 				int64_t pos = ftell(fpp);
-				fgets((char*) buf1, len, fpp);
-				fgets((char*) buf1, len, fpp);
+				err_fgets((char*) buf1, len, fpp);
+				err_fgets((char*) buf1, len, fpp);
 				if (buf1[0] == '+')
 					break;
-				fseek(fpp, pos, SEEK_SET);
+				err_fseek(fpp, pos, SEEK_SET);
 			}
-			position = ftell(fpp);
+			position = err_ftell(fpp);
 		}
 		else break;
 	}
@@ -918,7 +918,7 @@ int main_mem(int argc, char *argv[])
 		rewind(fr);
 
 		/* Reading ref. sequence */
-		fread(ref_string, 1, rlen, fr);
+		err_fread_noeof(ref_string, 1, rlen, fr);
 
 		uint64_t timer  = __rdtsc();
 		tprof[REF_IO][0] += timer - tim;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -208,6 +208,17 @@ int err_fputc(int c, FILE *stream)
 	return ret;
 }
 
+char* err_fgets(char *str, int size, FILE *stream)
+{
+	char* ret = fgets(str, size, stream );
+	if (ret == NULL)
+	{
+		_err_fatal_simple("fgets", strerror(errno));
+	}
+
+	return ret;
+}
+
 int err_fputs(const char *s, FILE *stream)
 {
 	int ret = fputs(s, stream);

--- a/src/utils.h
+++ b/src/utils.h
@@ -84,7 +84,7 @@ extern "C" {
 	FILE *err_xopen_core(const char *func, const char *fn, const char *mode);
 	FILE *err_xreopen_core(const char *func, const char *fn, const char *mode, FILE *fp);
 	gzFile err_xzopen_core(const char *func, const char *fn, const char *mode);
-    size_t err_fwrite(const void *ptr, size_t size, size_t nmemb, FILE *stream);
+	size_t err_fwrite(const void *ptr, size_t size, size_t nmemb, FILE *stream);
 	size_t err_fread_noeof(void *ptr, size_t size, size_t nmemb, FILE *stream);
 
 	int err_gzread(gzFile file, void *ptr, unsigned int len);

--- a/src/utils.h
+++ b/src/utils.h
@@ -97,6 +97,7 @@ extern "C" {
         ATTRIBUTE((format(printf, 1, 2)));
 	int err_fputc(int c, FILE *stream);
 #define err_putchar(C) err_fputc((C), stdout)
+	char* err_fgets(char *str, int size, FILE *stream);
 	int err_fputs(const char *s, FILE *stream);
 	int err_puts(const char *s);
 	int err_fflush(FILE *stream);


### PR DESCRIPTION
Set of patches to check all IO to ensure it succeeds. Failing to do this causes failures related to reads which may give the illusion of succeeding where they have in fact failed. This means the buffer contents is then undefined and may contain stale data. On network file systems this is a real issue.