### PR TITLE
add mem_reorder_primary5 calls to non-AVX512 path

### DIFF
--- a/src/bwamem_pair.cpp
+++ b/src/bwamem_pair.cpp
@@ -341,6 +341,12 @@ int mem_sam_pe(const mem_opt_t *opt, const bntseq_t *bns,
 
     n_pri[0] = mem_mark_primary_se(opt, a[0].n, a[0].a, id<<1|0);
     n_pri[1] = mem_mark_primary_se(opt, a[1].n, a[1].a, id<<1|1);  
+#if V17
+    if (opt->flag & MEM_F_PRIMARY5) {
+        mem_reorder_primary5(opt->T, &a[0]);
+        mem_reorder_primary5(opt->T, &a[1]);
+    }
+#endif
     if (opt->flag&MEM_F_NOPAIRING) goto no_pairing;
 
     // pairing single-end hits

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -871,7 +871,7 @@ int main_mem(int argc, char *argv[])
             aux.fmi->idx->bns->anns[i].is_alt = 0;
 
     /* READS file operations */
-    fp = gzopen(argv[optind + 1], "r");
+    fp = strcmp(argv[optind + 1], "-") ? gzopen(argv[optind + 1], "r") : gzdopen(STDIN_FILENO, "r");
     if (fp == 0)
     {
         fprintf(stderr, "[E::%s] fail to open file `%s'.\n", __func__, argv[optind + 1]);


### PR DESCRIPTION
mem_reorder_primary5 (the -5 option) only gets called on the AVX512 path, this adds it back to the non-AVX512 path (same call location as original bwa mem)