### PR TITLE
multi: Main binary now honours portable flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,10 @@
 ##                                Heng Li <hli@jimmy.harvard.edu> 
 ##*****************************************************************************************/
 
+ifneq ($(portable),)
+	STATIC_GCC=-static-libgcc -static-libstdc++
+endif
+
 EXE=		bwa-mem2
 #CXX=		icpc
 ifeq ($(CXX), icpc)
@@ -39,17 +43,13 @@ ARCH_FLAGS=	-msse4.1
 MEM_FLAGS=	-DSAIS=1
 CPPFLAGS=	-DENABLE_PREFETCH -DV17=1 $(MEM_FLAGS) 
 INCLUDES=   -Isrc -Iext/safestringlib/include
-LIBS=		-lpthread -lm -lz -L. -lbwa  -Lext/safestringlib -lsafestring
+LIBS=		-lpthread -lm -lz -L. -lbwa -Lext/safestringlib -lsafestring $(STATIC_GCC)
 OBJS=		src/fastmap.o src/bwtindex.o src/utils.o src/memcpy_bwamem.o src/kthread.o \
 			src/kstring.o src/ksw.o src/bntseq.o src/bwamem.o src/profiling.o src/bandedSWA.o \
 			src/FMI_search.o src/read_index_ele.o src/bwamem_pair.o src/kswv.o src/bwa.o \
 			src/bwamem_extra.o src/kopen.o
 BWA_LIB=    libbwa.a
 SAFE_STR_LIB=    ext/safestringlib/libsafestring.a
-
-ifneq ($(portable),)
-	LIBS+=-static-libgcc -static-libstdc++
-endif
 
 ifeq ($(arch),sse)
 		ARCH_FLAGS=-msse4.1
@@ -89,7 +89,7 @@ multi:
 	$(MAKE) arch=avx2   EXE=bwa-mem2.avx2     CXX=$(CXX) all
 	rm -f src/*.o $(BWA_LIB); cd ext/safestringlib/ && $(MAKE) clean;
 	$(MAKE) arch=avx512 EXE=bwa-mem2.avx512bw CXX=$(CXX) all
-	$(CXX) -Wall -O3 src/runsimd.cpp -Iext/safestringlib/include -Lext/safestringlib/ -lsafestring -o bwa-mem2
+	$(CXX) -Wall -O3 src/runsimd.cpp -Iext/safestringlib/include -Lext/safestringlib/ -lsafestring $(STATIC_GCC) -o bwa-mem2
 
 $(EXE):$(BWA_LIB) $(SAFE_STR_LIB) src/main.o
 	$(CXX) $(CXXFLAGS) src/main.o $(BWA_LIB) $(LIBS) -o $@


### PR DESCRIPTION
I hope you also find this patch useful.  I was unable to build a portable "multi" binary without this patch.

Without this patch:
```
$ ldd bwa-mem2
	linux-vdso.so.1 =>  (0x00007fff7a3e3000)
	libstdc++.so.6 => /hpc/software/installed/gcc/9.2.0/lib64/libstdc++.so.6 (0x00007ff80fed6000)
	libm.so.6 => /lib64/libm.so.6 (0x00007ff80fbd4000)
	libgcc_s.so.1 => /hpc/software/installed/gcc/9.2.0/lib64/libgcc_s.so.1 (0x00007ff80f9bc000)
	libc.so.6 => /lib64/libc.so.6 (0x00007ff80f5ee000)
	/lib64/ld-linux-x86-64.so.2 (0x00007ff8102af000)
```

With this patch:
```
$ ldd bwa-mem2
	linux-vdso.so.1 =>  (0x00007ffea305a000)
	libm.so.6 => /lib64/libm.so.6 (0x00007ff4827eb000)
	libc.so.6 => /lib64/libc.so.6 (0x00007ff48241d000)
	/lib64/ld-linux-x86-64.so.2 (0x00007ff482aed000)
```