### PR TITLE
Performance optimizations to the mate rescue step for paired-end reads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ $(SAFE_STR_LIB):
 	cd ext/safestringlib/ && $(MAKE) clean && $(MAKE) CC=$(CC) directories libsafestring.a
 
 clean:
-	rm -fr src/*.o $(BWA_LIB) $(EXE) bwa-mem2.sse41 bwa-mem2.avx2 bwa-mem2.avx512bw
+	rm -fr src/*.o $(BWA_LIB) $(EXE) bwa-mem2.sse41 bwa-mem2.sse42 bwa-mem2.avx bwa-mem2.avx2 bwa-mem2.avx512bw
 	cd ext/safestringlib/ && $(MAKE) clean
 
 depend:


### PR DESCRIPTION
This pull request contains changes to speed up the mate-rescue step for paired-end reads. Sorting of alignments is removed from the inner loop. Speedups are seen for datasets that spend significant time in worker_sam (e.g., poorly aligning read pairs at the end of Illumina Platinum Genomes).

Benchmarking:
* Machine: Intel(R) Xeon(R) CPU E5-2697 v3 @ 2.60GHz, 56 threads
* Dataset: 1 million reads from the end of [ERR194147_1.fastq.gz](https://storage.googleapis.com/genomics-public-data/platinum-genomes/fastq/ERR194147_1.fastq.gz) and [ERR194147_2.fastq.gz](https://storage.googleapis.com/genomics-public-data/platinum-genomes/fastq/ERR194147_2.fastq.gz)

Results: AVX2 mode

* BWA-MEM2 (master):
```
Runtime profile:

	Time taken for main_mem function: 191.99 sec

	IO times (sec) :
	Reading IO time (reads) avg: 17.58, (17.58, 17.58)
	Writing IO time (SAM) avg: 10.13, (10.13, 10.13)
	Reading IO time (Reference Genome) avg: 4.64, (4.64, 4.64)
	Index read time avg: 10.72, (10.72, 10.72)

	Overall time (sec) (Excluding Index reading time):
	PROCESS() (Total compute time + (read + SAM) IO time) : 174.52
	MEM_PROCESS_SEQ() (Total compute time (Kernel + SAM)), avg: 170.92, (170.92, 170.92)

	 SAM Processing time (sec):
	--WORKER_SAM avg: 101.80, (101.80, 101.80)

	Kernels' compute time (sec):
	Total kernel (smem+sal+bsw) time avg: 68.63, (68.63, 68.63)
		SMEM compute avg: 6.37, (7.11, 5.58)
		SAL compute avg: 11.02, (12.02, 10.29)
				MEM_SA avg: 3.86, (4.55, 3.37)

		BSW time, avg: 34.44, (35.90, 33.23)
```

* BWA-MEM2 (mate-rescue sorting optimization):
```
Runtime profile:

	Time taken for main_mem function: 146.16 sec

	IO times (sec) :
	Reading IO time (reads) avg: 22.82, (22.82, 22.82)
	Writing IO time (SAM) avg: 10.97, (10.97, 10.97)
	Reading IO time (Reference Genome) avg: 4.34, (4.34, 4.34)
	Index read time avg: 8.30, (8.30, 8.30)

	Overall time (sec) (Excluding Index reading time):
	PROCESS() (Total compute time + (read + SAM) IO time) : 130.88
	MEM_PROCESS_SEQ() (Total compute time (Kernel + SAM)), avg: 127.53, (127.53, 127.53)

	 SAM Processing time (sec):
	--WORKER_SAM avg: 61.70, (61.70, 61.70)

	Kernels' compute time (sec):
	Total kernel (smem+sal+bsw) time avg: 65.38, (65.38, 65.38)
		SMEM compute avg: 10.11, (11.09, 9.21)
		SAL compute avg: 15.08, (15.90, 14.46)
				MEM_SA avg: 6.61, (7.21, 5.96)

		BSW time, avg: 26.25, (27.23, 25.03)
```

* Same SAM output as BWA-MEM2 master with 23.8 % wall-clock speedup and 39.4% worker_sam speedup.
```
25c25
< @PG	ID:bwa-mem2	PN:bwa-mem2	VN:2.1	CL:./bwa-mem2 mem -K 100000000 -t 56 -Y /x/arunsub/index/bwa-mem2/hg38 /x/arunsub/reads/tail_1m_1.fastq /x/arunsub/reads/tail_1m_2.fastq -o /x/arunsub/sam/tail_1m_mem2_orig.sam
---
> @PG	ID:bwa-mem2	PN:bwa-mem2	VN:2.1	CL:./bwa-mem2 mem -K 100000000 -t 56 -Y /x/arunsub/index/bwa-mem2/hg38 /x/arunsub/reads/tail_1m_1.fastq /x/arunsub/reads/tail_1m_2.fastq -o /x/arunsub/sam/tail_1m_mem2.sam
```
