### PR TITLE
Speed-up reading of large header files

### DIFF
--- a/src/bwa.h
+++ b/src/bwa.h
@@ -104,6 +104,7 @@ extern "C" {
 	void bwa_print_sam_hdr(const bntseq_t *bns, const char *hdr_line, FILE *fp);
 	char *bwa_set_rg(const char *s);
 	char *bwa_insert_header(const char *s, char *hdr);
+	char *bwa_insert_header_file(const FILE *fp, char *hdr);
 #ifdef __cplusplus
 }
 #endif

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -739,17 +739,7 @@ int main_mem(int argc, char *argv[])
                 FILE *fp;
                 if ((fp = fopen(optarg, "r")) != 0)
                 {
-                    char *buf;
-                    buf = (char *) calloc(1, 0x10000);
-                    assert(buf != NULL);
-                    while (fgets(buf, 0xffff, fp))
-                    {
-                        i = strlen(buf);
-                        assert(buf[i-1] == '\n');
-                        buf[i-1] = 0;
-                        hdr_line = bwa_insert_header(buf, hdr_line);
-                    }
-                    free(buf);
+                    bwa_insert_header_file(fp, hdr_line);
                     fclose(fp);
                 }
             } else hdr_line = bwa_insert_header(optarg, hdr_line);


### PR DESCRIPTION
When a large file was passed to the -H parameter, bwa-mem2 spent more than 10 minutes just reading the lines from the file (I experienced this on a 70MB file with ~1.5M lines).

This was caused by computing the length of the already parsed header and reallocating the string for every single line in the input file resulting in quadratic complexity. The new implementation allocates a buffer that is able to fit the whole file up front  and then reads all "valid" lines into the buffer before calling the original `bwa_insert_header` implementation. With this change the reading of header file takes <1s.