### PR TITLE
Fix threading reproducibility issue by moving n_processed update line from step 2 to step 1

### DIFF
--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -293,12 +293,12 @@ ktp_data_t *kt_pipeline(void *shared, int step, void *data, mem_opt_t *opt, work
         }               
         tprof[MEM_PROCESS2][0] += __rdtsc() - tim;
                 
+        aux->n_processed += ret->n_seqs;
         return ret;
     }           
     /* Step 3: Write output */
     else if (step == 2)
     {
-        aux->n_processed += ret->n_seqs;
         uint64_t tim = __rdtsc();
 
         for (int i = 0; i < ret->n_seqs; ++i)


### PR DESCRIPTION
This PR fixes the issue mentioned in https://github.com/bwa-mem2/bwa-mem2/issues/228. 

A race condition occurs when aux->n_processed is updated in step 2 of the pipeline. If steps 1 and 2 run simultaneously in different pipelines, n_processed may change, affecting the hash calculation in step 1 when choosing a primary alignment from among multiple equally good alignments. 

Note that in the original bwa, aux->n_processed is updated in step 1, and it does not have this reproducibility issue. With the fix in place, all of the problems described in https://github.com/bwa-mem2/bwa-mem2/issues/228 are fixed. 