### PR TITLE
Fix smem allocation bug

### DIFF
--- a/src/FMI_search.h
+++ b/src/FMI_search.h
@@ -114,7 +114,8 @@ class FMI_search: public indexEle
                                  int32_t  max_readlength,
                                  int32_t minSeedLen,
                                  SMEM *matchArray,
-                                 int64_t *__numTotalSmem);
+                                 int64_t *__numTotalSmem,
+                                 int64_t max_smem);
     
     void getSMEMsAllPosOneThread(uint8_t *enc_qdb,
                                  int32_t *min_intv_array,
@@ -126,7 +127,8 @@ class FMI_search: public indexEle
                                  int32_t max_readlength,
                                  int32_t minSeedLen,
                                  SMEM *matchArray,
-                                 int64_t *__numTotalSmem);
+                                 int64_t *__numTotalSmem,
+                                 int64_t max_smem);
         
     
     int64_t bwtSeedStrategyAllPosOneThread(uint8_t *enc_qdb,
@@ -135,7 +137,8 @@ class FMI_search: public indexEle
                                            const bseq1_t *seq_,
                                            int32_t *query_cum_len_ar,
                                            int32_t minSeedLen,
-                                           SMEM *matchArray);
+                                           SMEM *matchArray,
+                                           int64_t max_smem);
         
     void sortSMEMs(SMEM *matchArray,
                    int64_t numTotalSmem[],

--- a/src/bwamem.h
+++ b/src/bwamem.h
@@ -105,6 +105,7 @@ typedef struct mem_opt_t {
     int max_matesw;         // perform maximally max_matesw rounds of mate-SW for each end
     int max_XA_hits, max_XA_hits_alt; // if there are max_hits or fewer, output them all
     int8_t mat[25];         // scoring matrix; mat[0] == 0 if unset
+    int max_read_length;    // maximum read length expected, needed for allocating memory
 } mem_opt_t;
 
 

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -293,12 +293,12 @@ ktp_data_t *kt_pipeline(void *shared, int step, void *data, mem_opt_t *opt, work
         }               
         tprof[MEM_PROCESS2][0] += __rdtsc() - tim;
                 
+        aux->n_processed += ret->n_seqs;
         return ret;
     }           
     /* Step 3: Write output */
     else if (step == 2)
     {
-        aux->n_processed += ret->n_seqs;
         uint64_t tim = __rdtsc();
 
         for (int i = 0; i < ret->n_seqs; ++i)


### PR DESCRIPTION
This PR introduces an optional max read length argument (-l [read length], i.e., lowercase "el") to bwa-mem2, that can be used to increase memory allocation for smem -- the data structure used to store FM index matches. The previously hard-coded value of 151 for read length sometimes leads to memory errors or segfaults in situations where read length is longer.

Changes also include a memory check in all related FM index search methods to catch any memory errors before segfault occurs.

**Note:** this PR also includes the 1-line change for reproducibility in this PR: https://github.com/bwa-mem2/bwa-mem2/pull/229.

Related to issue: https://github.com/bwa-mem2/bwa-mem2/issues/210.